### PR TITLE
Fix patch issue in installing Python version < 3.5

### DIFF
--- a/scripts/package-setup.sh
+++ b/scripts/package-setup.sh
@@ -3,6 +3,7 @@
 apk add --no-cache --update \
   bash \
   build-base \
+  patch \
   ca-certificates \
   git \
   bzip2-dev \


### PR DESCRIPTION
Hi,

It seems alpine uses a custom version of the program `patch` which does not contain an option used by `pyenv`. Installing the patch directly from `apk` solves the problem, hence this PR.